### PR TITLE
MarkdownLoader, Post 로직 관련 1차 리팩토링

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     "import/no-unresolved": 0,
     "import/extensions": 0,
     "class-methods-use-this": 0,
+    "lines-between-class-members": 0,
     "no-useless-constructor": 0,
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-var-requires": 0,

--- a/src/libs/FileLoader/MarkdownLoader.ts
+++ b/src/libs/FileLoader/MarkdownLoader.ts
@@ -1,23 +1,6 @@
-import FilePathParser, { Item } from "../FilePathParser/FilePathParser";
 import FileLoader from "./FileLoader";
 
-class MarkdownLoader extends FileLoader {
-  findAllWithFormat(): Item[] {
-    const list: Item[] = [];
-
-    const parser = new FilePathParser();
-
-    this.paths.forEach((path) => {
-      const item = parser.parse(path);
-
-      if (item != null) {
-        list.push(item);
-      }
-    });
-
-    return list;
-  }
-}
+class MarkdownLoader extends FileLoader {}
 
 const postsContext = require.context("@/_posts", false, /\.md$/);
 

--- a/src/libs/FilePathParser/FilePathParser.ts
+++ b/src/libs/FilePathParser/FilePathParser.ts
@@ -1,37 +1,21 @@
-export type Item = {
-  title: string;
-  date?: string;
-};
+import Validator from "../Validator/Validator";
 
 class FilePathParser {
-  private validate(title: string, date?: string) {
-    const isDate = /\d{4}-\d{1,2}-\d{1,2}/gi;
-    const isTitle = /[a-z0-9ㄱ-힣\s$&+,:;=?@#|'<>.^*()%!-]+/gi;
-
-    if (date && !date.match(isDate)) {
-      throw new Error("Invalid date!");
-    }
-
-    if (!title.match(isTitle)) {
-      throw new Error("Invalid title!");
-    }
-  }
-
-  parse(path: string): Item | null {
+  parse(path: string): string[] {
     const regExp =
       /(.\/(?:[a-z_/]+)?)?(\d{4}-\d{2}-\d{2})?(?:-+)?([a-z0-9ㄱ-힣\s$&+,:;=?@#|'<>.^*()%!-]+)(\.[a-z]+)/im;
 
     const matched = path.match(regExp);
 
     if (!matched) {
-      return null;
+      throw new Error("Invalid file path.");
     }
 
-    const [, , date, title] = matched;
+    const [, , createdAt, title] = matched;
 
-    this.validate(date, title);
+    new Validator().isFilled(title).isDate(createdAt);
 
-    return { title, date };
+    return [title, createdAt];
   }
 }
 

--- a/src/libs/Validator/Validator.ts
+++ b/src/libs/Validator/Validator.ts
@@ -1,0 +1,29 @@
+class Validator {
+  isFilled(value: string): this {
+    const regExp = /\s/gm;
+    const replaced = value.replace(regExp, "");
+
+    if (replaced === "") {
+      throw new Error("String value is empty!");
+    }
+
+    return this;
+  }
+
+  isDate(date: string): this {
+    if (!date) {
+      return this;
+    }
+
+    const regExp = /\d{4}-\d{1,2}-\d{1,2}/gi;
+    const matched = date.match(regExp);
+
+    if (!matched) {
+      throw new Error("String date does not match the format!");
+    }
+
+    return this;
+  }
+}
+
+export default Validator;

--- a/src/models/post.ts
+++ b/src/models/post.ts
@@ -1,0 +1,11 @@
+class Post {
+  title: string;
+  createdAt?: string;
+
+  constructor(title: string, createdAt?: string) {
+    this.title = title;
+    this.createdAt = createdAt;
+  }
+}
+
+export default Post;

--- a/src/repositories/postRepository.ts
+++ b/src/repositories/postRepository.ts
@@ -1,0 +1,21 @@
+import markdownLoader from "@/libs/FileLoader/MarkdownLoader";
+import FilePathParser from "@/libs/FilePathParser/FilePathParser";
+import Post from "@/models/post";
+
+class PostRepository {
+  fetchPosts(): Post[] {
+    const { paths } = markdownLoader;
+
+    const parser = new FilePathParser();
+
+    const posts = paths.map((path) => {
+      const [title, createdAt] = parser.parse(path);
+
+      return new Post(title, createdAt);
+    });
+
+    return posts;
+  }
+}
+
+export default PostRepository;


### PR DESCRIPTION
### Short Description

- 각 클래스별 역할이 명확하도록 리펙토링한다.


### Proposed changes

- MarkdownLoader 클래스가 **Markdown 파일을 불러오는 것**에 초점을 맞추도록 parsing 로직을 제거한다.
- FilePathParser 클래스가 **file path를 정해진 데이터로 변환하는 것에 초점**을 맞추도록 validate 함수를 재사용 가능한 클래스로 분리한다.
- PostRepository를 생성, FilePathParser를 이용해서 markdown file path를 정해진 데이터로 변환하여 Post 모델에 담을 수 있도록 로직을 구성한다.